### PR TITLE
feat: Add `.` access getter for hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ let hash = {
 };
 
 hash["name"];
+hash.name;
 hash["a" + "ge"];
 hash[true];
 hash[99];

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -519,7 +519,9 @@ let two = "two";
     fn test_hash_index_expr() {
         let tests = vec![
             ("{\"foo\": 5}[\"foo\"]", Some(Object::Int(5))),
+            ("{\"foo\": 5}.foo", Some(Object::Int(5))),
             ("{\"foo\": 5}[\"bar\"]", Some(Object::Null)),
+            ("{\"foo\": 5}.bar", Some(Object::Null)),
             ("let key = \"foo\"; {\"foo\": 5}[key]", Some(Object::Int(5))),
             ("{}[\"foo\"]", Some(Object::Null)),
             ("{5: 5}[5]", Some(Object::Int(5))),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -102,6 +102,7 @@ impl<'a> Lexer<'a> {
             b'}' => Token::Rbrace,
             b'[' => Token::Lbracket,
             b']' => Token::Rbracket,
+            b'.' => Token::Dot,
             b',' => Token::Comma,
             b';' => Token::Semicolon,
             b':' => Token::Colon,

--- a/src/token.rs
+++ b/src/token.rs
@@ -30,6 +30,7 @@ pub enum Token {
     GreaterThanEqual,
 
     // Delimiters
+    Dot,
     Comma,
     Colon,
     Semicolon,


### PR DESCRIPTION
Support the feature of `.` access getter for hash

```
let hash = {
  "name": "Jimmy",
  "age": 72,
  true: "a boolean",
  99: "an integer"
};

hash.name;
```